### PR TITLE
Add Trino CLI dependencies

### DIFF
--- a/local-files/config.properties
+++ b/local-files/config.properties
@@ -1,6 +1,6 @@
 # Minimal setup for single node installation with metrics endpoint.
 coordinator=true
-node-scheduler.include-coordinator=false
+node-scheduler.include-coordinator=true
 http-server.http.port=8080
 discovery.uri=http://localhost:8080
 jmx.rmiregistry.port=9081

--- a/local-files/trino-cli.sh
+++ b/local-files/trino-cli.sh
@@ -1,0 +1,2 @@
+export PATH="${JAVA_HOME}/bin:${PATH}"
+./trino

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -106,12 +106,17 @@ parts:
       - usr/lib/trino/etc/config.properties
       - usr/lib/trino/etc/trino/jmx/config.yaml
       - entrypoint.sh
+      - trino-cli.sh
     permissions:
       - path: usr/lib/trino/etc
         owner: 584792
         group: 584792
         mode: "755"
       - path: entrypoint.sh
+        owner: 584792
+        group: 584792
+        mode: "755"
+      - path: trino-cli.sh
         owner: 584792
         group: 584792
         mode: "755"
@@ -171,6 +176,21 @@ parts:
         group: 584792
         mode: "755"
 
+  trino-cli:
+    plugin: dump
+    source: https://repo.maven.apache.org/maven2/io/trino/trino-cli/418/trino-cli-418-executable.jar # yamllint disable-line
+    source-checksum: sha1/6cc447532d8722f78529257c13f8ab51e7481b15
+    source-type: file
+    organize:
+      trino-cli-418-executable.jar: trino
+    stage:
+      - trino
+    permissions:
+      - path: trino
+        owner: 584792
+        group: 584792
+        mode: "755"
+
   package-management:
     plugin: nil
     after: [trino, local-files, ranger-plugin]
@@ -179,3 +199,4 @@ parts:
       - python-is-python3
     stage-packages:
       - openjdk-21-jdk-headless
+      - less


### PR DESCRIPTION
Add Trino CLI dependencies to the ROCK such that when a user SSH's into the charm container they are able to use the trino cli to execute commands. Much the same as `psql` in the postgresql charm.

More details on Trino cli can be found here: https://trino.io/docs/current/client/cli.html.

The change of `node-scheduler.include-coordinator` from `false` to `true` rectifies a previous mistake - if this value is false then the Trino deployment is of the coordinator service only with no worker capacity. If true then the single node deployment acts as both coordinator and worker. This was the original intention with the rock service.