### PR TITLE
CSS-8767 Use Ranger groups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
     needs:
       - lint
     steps:

--- a/local-files/ranger-trino-security.xml
+++ b/local-files/ranger-trino-security.xml
@@ -1,0 +1,82 @@
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration>
+  <property>
+    <name>ranger.plugin.trino.service.name</name>
+    <value>trinoservice</value>
+    <description>
+      Name of the Ranger service containing policies for this Trino instance
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.use.rangerGroups</name>
+    <value>true</value>
+    <description>
+      Use user groups from Ranger admin
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.source.impl</name>
+    <value>org.apache.ranger.admin.client.RangerAdminRESTClient</value>
+    <description>
+      Class to retrieve policies from the source
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.rest.url</name>
+    <value>http://localhost:6080</value>
+    <description>
+      URL to Ranger Admin
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.rest.ssl.config.file</name>
+    <value>/etc/hadoop/conf/ranger-policymgr-ssl.xml</value>
+    <description>
+      Path to the file containing SSL details to contact Ranger Admin
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.pollIntervalMs</name>
+    <value>30000</value>
+    <description>
+      How often to poll for changes in policies?
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.rest.client.connection.timeoutMs</name>
+    <value>30000</value>
+    <description>
+      S3 Plugin RangerRestClient Connection Timeout in Milli Seconds
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.trino.policy.rest.client.read.timeoutMs</name>
+    <value>30000</value>
+    <description>
+      S3 Plugin RangerRestClient read Timeout in Milli Seconds
+    </description>
+  </property>
+</configuration>

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -149,6 +149,8 @@ parts:
         --strip-components=1
     stage:
       - usr/lib/ranger
+        # We will not stage the `ranger-trino-security.xml.
+        # We are staging this from local-files`
       - "-usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml" # yamllint disable-line
     permissions:
       - path: usr/lib/ranger

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -91,7 +91,7 @@ parts:
         mode: "755"
 
   local-files:
-    after: [trino]
+    after: [trino, ranger-plugin]
     plugin: dump
     source: ./local-files
     organize:
@@ -100,7 +100,9 @@ parts:
       config.properties: usr/lib/trino/etc/config.properties
       jmx-config.yaml: usr/lib/trino/etc/trino/jmx/config.yaml
       trino-entrypoint.sh: entrypoint.sh
+      ranger-trino-security.xml: usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml # yamllint disable-line
     stage:
+      - usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml
       - usr/lib/trino/etc/jvm.config
       - usr/lib/trino/etc/node.properties
       - usr/lib/trino/etc/config.properties
@@ -122,12 +124,15 @@ parts:
         mode: "755"
 
   ranger-plugin:
-    after: [trino, local-files]
+    after: [trino]
     plugin: maven
     maven-parameters: ["-DskipTests=true", "-P ranger-trino-plugin,-linux -am", "-pl distro,plugin-trino,ranger-trino-plugin-shim,agents-installer,credentialbuilder"] # yamllint disable-line
-    source: "https://downloads.apache.org/ranger/2.4.0/apache-ranger-2.4.0.tar.gz" # yamllint disable-line
-    source-type: "tar"
-    source-checksum: "sha512/5bc934416e7239e2b74843399389a69e8c129322ff0a67b2e7a541a4dd2171357b10925ea29861c40e7590a6523494d46343fdda38049d9a66e48d80eed11a4b" # yamllint disable-line
+    source: https://github.com/apache/ranger.git
+    # Commit from 08/04/24, after introduction of:
+    # prometheus compatible metrics (d745caa4c539aaeb239fac4931ae7df899667d9d).
+    # use.rangerGroups commit (84cb3c465c5c6dc71e369a9ccdc1594059b626ae).
+    source-commit: d745caa4c539aaeb239fac4931ae7df899667d9d
+    source-type: git
     build-packages:
       - build-essential
       - maven
@@ -139,11 +144,12 @@ parts:
       mkdir -p ${CRAFT_PART_INSTALL}/usr/lib/ranger
 
       # Unpack trino plugin file
-      tar xvfz target/ranger-2.4.0-trino-plugin.tar.gz \
+      tar xvfz target/ranger-3.0.0-SNAPSHOT-trino-plugin.tar.gz \
         --directory=${CRAFT_PART_INSTALL}/usr/lib/ranger/ \
         --strip-components=1
     stage:
       - usr/lib/ranger
+      - "-usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml" # yamllint disable-line
     permissions:
       - path: usr/lib/ranger
         owner: 584792


### PR DESCRIPTION
2 updates are introduced with this PR in order to have Trino use Ranger groups as opposed to unix.
1. Upgrade of Ranger - Ranger must be upgraded to a version after this commit which introduced this functionality: https://github.com/apache/ranger/commit/84cb3c465c5c6dc71e369a9ccdc1594059b626ae.
2. Replacement of the `ranger-trino-security.xml` file generated on maven build with one containing the `use.rangerGroup` property, with value set to `true`.