### PR TITLE
CSS-10231 Adds apache2-utils and fixes source-commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,10 @@ jobs:
         run: |
           sudo snap install yq
           sudo snap install rockcraft --classic --edge
+      - name: Cleanup previous mounts
+        run: |
+          sudo umount /root/overlay/overlay || true
+          sudo rm -rf /root/overlay/overlay || true
       - name: Build ROCK
         run: |
           app_version=$(yq '.version' rockcraft.yaml)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
           sudo snap install rockcraft --classic --edge
       - name: Cleanup previous mounts
         run: |
-          sudo umount /root/overlay/overlay || true
+          sudo umount -l /root/overlay/overlay || true
           sudo rm -rf /root/overlay/overlay || true
       - name: Build ROCK
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,14 +30,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup LXD
         uses: canonical/setup-lxd@main
+        with:
+          channel: 5.20/stable
       - name: Install dependencies
         run: |
           sudo snap install yq
           sudo snap install rockcraft --classic --edge
-      - name: Cleanup previous mounts
-        run: |
-          sudo umount -l /root/overlay/overlay || true
-          sudo rm -rf /root/overlay/overlay || true
       - name: Build ROCK
         run: |
           app_version=$(yq '.version' rockcraft.yaml)

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -128,10 +128,10 @@ parts:
     plugin: maven
     maven-parameters: ["-DskipTests=true", "-P ranger-trino-plugin,-linux -am", "-pl distro,plugin-trino,ranger-trino-plugin-shim,agents-installer,credentialbuilder"] # yamllint disable-line
     source: https://github.com/apache/ranger.git
-    # Commit from 08/04/24, after introduction of:
+    # Commit from 08/09/23, after introduction of:
     # prometheus compatible metrics (d745caa4c539aaeb239fac4931ae7df899667d9d).
     # use.rangerGroups commit (84cb3c465c5c6dc71e369a9ccdc1594059b626ae).
-    source-commit: d745caa4c539aaeb239fac4931ae7df899667d9d
+    source-commit: 84cb3c465c5c6dc71e369a9ccdc1594059b626ae
     source-type: git
     build-packages:
       - build-essential
@@ -208,3 +208,4 @@ parts:
     stage-packages:
       - openjdk-21-jdk-headless
       - less
+      - apache2-utils


### PR DESCRIPTION
This PR adds the apache-utils to the rock for use by the charm when setting the trino username and passwords in the `password.db`  with `htpasswd`.

Note: it also fixes an error where the latest commit used was the Prometheus commit when it should have been the ranger group commit as this was a more recent commit.

And pins lxd revision to 5.20/stable due to this bug: https://github.com/canonical/rockcraft/issues/195