### PR TITLE
CSS-11009 Add the bigquery plugin to the Trino rock

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -64,6 +64,7 @@ parts:
     organize:
       bin: usr/lib/trino/bin
       lib: usr/lib/trino/lib
+      plugin/bigquery: usr/lib/trino/plugin/bigquery
       plugin/elasticsearch: usr/lib/trino/plugin/elasticsearch
       plugin/google-sheets: usr/lib/trino/plugin/google-sheets
       plugin/mysql: usr/lib/trino/plugin/mysql


### PR DESCRIPTION
Stages the already built bigquery plugin so it's available in the final charm.