### PR TITLE
Add the hive plugin to support hive metadata store

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.20/stable
+          channel: 5.21/stable
       - name: Install dependencies
         run: |
           sudo snap install yq

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -73,6 +73,7 @@ parts:
       plugin/prometheus: usr/lib/trino/plugin/prometheus
       plugin/redis: usr/lib/trino/plugin/redis
       plugin/ranger: usr/lib/trino/plugin/ranger
+      plugin/hive: usr/lib/trino/plugin/hive
       trino-cli: usr/lib/trino/bin/trino-cli
     stage:
       - data/trino


### PR DESCRIPTION
Makes the hive plugin available in the Trino rock - this is useful if wanting to use the hive connector for metadata.

Updates lxd version to avoid this unmount error when building rock: https://discourse.ubuntu.com/t/mount-root-proc-cannot-mount-proc-read-only-with-lxd-5-21-2-22f93f4-from-snap/47533