### PR TITLE
CSS-12446: upgrade Trino to 468

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
           rockcraft pack --verbose
 
       - name: Upload locally built ROCK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: charmed-trino-rock
           path: "charmed-trino-rock_*.rock"

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 REPO_FOLDER = charmed-trino-rock
 REPO = https://github.com/canonical/$(REPO_FOLDER).git
 ROCK_DEV = rock-dev
-ROCK_VERSION = 418
-UBUNTU_VER = 22.04
+ROCK_VERSION = 468
+UBUNTU_VER = 24.04
 DOCKER_NAME = trino-rock
 DOCKER_PORT = 8080
 DOCKER_ARGS = start trino-server

--- a/local-files/ranger-policymgr-ssl.xml
+++ b/local-files/ranger-policymgr-ssl.xml
@@ -1,0 +1,55 @@
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- properties used for 2-way SSL between the Trino plugin and Apache Ranger server -->
+  <property>
+    <name>xasecure.policymgr.clientssl.keystore</name>
+    <value></value>
+    <description>Path to keystore file. Only required for two-way SSL. This property should not be included for one-way SSL</description>
+  </property>
+
+  <property>
+    <name>xasecure.policymgr.clientssl.keystore.type</name>
+    <value>jks</value>
+    <description>Type of keystore. Default: jks</description>
+  </property>
+
+  <property>
+    <name>xasecure.policymgr.clientssl.keystore.credential.file</name>
+    <value></value>
+    <description>Path to credential file for the keystore; the credential should be in alias sslKeyStore. Only required for two-way SSL. This property should not be included for one-way SSL</description>
+  </property>
+
+  <property>
+    <name>xasecure.policymgr.clientssl.truststore</name>
+    <value></value>
+    <description>Path to truststore file</description>
+  </property>
+
+  <property>
+    <name>xasecure.policymgr.clientssl.truststore.type</name>
+    <value>jks</value>
+    <description>Type of truststore. Default: jks</description>
+  </property>
+
+  <property>
+    <name>xasecure.policymgr.clientssl.truststore.credential.file</name>
+    <value></value>
+    <description>Path to credential file for the truststore; the credential should be in alias sslTrustStore</description>
+  </property>
+</configuration>

--- a/local-files/ranger-trino-audit.xml
+++ b/local-files/ranger-trino-audit.xml
@@ -1,0 +1,36 @@
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<configuration xmlns:xi="http://www.w3.org/2001/XInclude">
+  <property>
+    <name>xasecure.audit.is.enabled</name>
+    <value>false</value>
+    <description>Boolean flag to specify if the plugin should generate access audit logs. Default: true</description>
+  </property>
+
+  <property>
+    <name>xasecure.audit.solr.is.enabled</name>
+    <value>false</value>
+    <description>Boolean flag to specify if audit logs should be stored in Solr. Default: false</description>
+  </property>
+
+  <property>
+    <name>xasecure.audit.solr.solr_url</name>
+    <value></value>
+    <description>URL to Solr deployment where the plugin should send access audits to</description>
+  </property>
+</configuration>

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -44,8 +44,9 @@ parts:
       - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
       - JAVA_URL: https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz # yamllint disable-line
     override-build: |
-      # TODO: the following block needs to be removed when
-      # openjdk-23-jdk-headless becomes available on 25.04
+      # TODO: the following block can be removed when the ubuntu base
+      # used for the rock supports the "openjdk-xx-jdk-headless"
+      # corrseponding to the java version used in Trino
       curl ${JAVA_URL} --output jdk-23.0.1.tar.gz
       mkdir -p ${JAVA_HOME}
       mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}
@@ -163,8 +164,8 @@ parts:
         mode: "755"
 
   # This is a workaround of an issue with ranger groups in trino 468
-  # the author is aware of the problem and is supposed to fix it in the
-  # next release. At that point this part can be deleted.
+  # The issue is tracked here:
+  # https://github.com/trinodb/trino/issues/24887
   trino-patch:
     plugin: nil
     after: [local-files]
@@ -188,8 +189,6 @@ parts:
     source: https://github.com/prometheus/jmx_exporter.git
     source-type: git
     source-tag: parent-0.19.0
-    # build-environment:
-    #   - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
     organize:
       jar/jmx_prometheus_javaagent-0.19.0.jar: usr/lib/trino/lib/jmx_prometheus_javaagent.jar # yamllint disable-line
     stage:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -53,8 +53,10 @@ parts:
       tar -xzf jdk-23.0.1.tar.gz
       cp -r jdk-23.0.1/* ${JAVA_HOME}
       cp -r jdk-23.0.1/* ${CRAFT_PART_INSTALL}${JAVA_HOME}
-      update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 1
-      update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1
+      update-alternatives --install \
+        /usr/bin/java java ${JAVA_HOME}/bin/java 1
+      update-alternatives --install \
+        /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1
       update-alternatives --set java ${JAVA_HOME}/bin/java
       update-alternatives --set javac ${JAVA_HOME}/bin/javac
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -42,12 +42,12 @@ parts:
       - maven
     build-environment:
       - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
+      - JAVA_URL: https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz # yamllint disable-line
     override-build: |
-      # TODO: the following block needs to be removed when 
+      # TODO: the following block needs to be removed when
       # openjdk-23-jdk-headless becomes available on 25.04
 
-      curl https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz\ # yamllint disable-line
-        --output jdk-23.0.1.tar.gz
+      curl ${JAVA_URL} --output jdk-23.0.1.tar.gz
       mkdir -p ${JAVA_HOME}
       mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}
       tar -xzf jdk-23.0.1.tar.gz
@@ -169,7 +169,7 @@ parts:
     after: [local-files]
     override-build: |
       mkdir -p /usr/lib/trino/etc/
-      touch /usr/lib/trino/etc/ranger-trino-security.xml 
+      touch /usr/lib/trino/etc/ranger-trino-security.xml
       touch /usr/lib/trino/etc/ranger-trino-audit.xml
       mkdir -p usr/lib/trino/plugin/apache-ranger/conf
       ln -s /usr/lib/trino/etc/ranger-trino-security.xml \

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -87,6 +87,7 @@ parts:
       plugin/redis: usr/lib/trino/plugin/redis
       plugin/apache-ranger: usr/lib/trino/plugin/apache-ranger
       plugin/hive: usr/lib/trino/plugin/hive
+      plugin/geospatial: usr/lib/trino/plugin/geospatial
       trino-cli: usr/lib/trino/bin/trino-cli
     stage:
       - data/trino

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -46,7 +46,6 @@ parts:
     override-build: |
       # TODO: the following block needs to be removed when
       # openjdk-23-jdk-headless becomes available on 25.04
-
       curl ${JAVA_URL} --output jdk-23.0.1.tar.gz
       mkdir -p ${JAVA_HOME}
       mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}
@@ -75,7 +74,6 @@ parts:
         ${CRAFT_PART_INSTALL}/data/trino/var/log \
         ${CRAFT_PART_INSTALL}/data/trino/var/cache \
         ${CRAFT_PART_INSTALL}/usr/lib/trino/var
-
     organize:
       bin: usr/lib/trino/bin
       lib: usr/lib/trino/lib
@@ -189,8 +187,8 @@ parts:
     source: https://github.com/prometheus/jmx_exporter.git
     source-type: git
     source-tag: parent-0.19.0
-    build-environment:
-      - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
+    # build-environment:
+    #   - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
     organize:
       jar/jmx_prometheus_javaagent-0.19.0.jar: usr/lib/trino/lib/jmx_prometheus_javaagent.jar # yamllint disable-line
     stage:
@@ -214,7 +212,6 @@ parts:
     plugin: nil
     after: [trino, local-files]
     overlay-packages:
-      # - openjdk-23-jdk-headless
       - ca-certificates
       - python-is-python3
     stage-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -43,22 +43,23 @@ parts:
     build-environment:
       - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
     override-build: |
-      # TODO: the following block needs to be removed when openjdk-23-jdk-headless becomes available on 25.04
+      # TODO: the following block needs to be removed when 
+      # openjdk-23-jdk-headless becomes available on 25.04
 
-      curl https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz\
-        --output jdk-23.0.1.tar.gz 
+      curl https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz\ # yamllint disable-line
+        --output jdk-23.0.1.tar.gz
       mkdir -p ${JAVA_HOME}
       mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}
       tar -xzf jdk-23.0.1.tar.gz
       cp -r jdk-23.0.1/* ${JAVA_HOME}
       cp -r jdk-23.0.1/* ${CRAFT_PART_INSTALL}${JAVA_HOME}
       update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 1
-      update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1      
+      update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1
       update-alternatives --set java ${JAVA_HOME}/bin/java
       update-alternatives --set javac ${JAVA_HOME}/bin/javac
 
-
-      ./mvnw clean install -DskipTests -Dair.check.skip-all=true -pl '!:trino-server-rpm,!docs'
+      ./mvnw clean install -DskipTests -Dair.check.skip-all=true \
+        -pl '!:trino-server-rpm,!docs'
 
       tar -xzf core/trino-server/target/trino-server-*.tar.gz \
         --directory=${CRAFT_PART_INSTALL} \
@@ -160,7 +161,7 @@ parts:
         group: 584792
         mode: "755"
 
-  # This is a workaround of an issue with ranger groups in trino 468 
+  # This is a workaround of an issue with ranger groups in trino 468
   # the author is aware of the problem and is supposed to fix it in the
   # next release. At that point this part can be deleted.
   trino-patch:
@@ -168,10 +169,13 @@ parts:
     after: [local-files]
     override-build: |
       mkdir -p /usr/lib/trino/etc/
-      touch /usr/lib/trino/etc/ranger-trino-security.xml /usr/lib/trino/etc/ranger-trino-audit.xml
+      touch /usr/lib/trino/etc/ranger-trino-security.xml 
+      touch /usr/lib/trino/etc/ranger-trino-audit.xml
       mkdir -p usr/lib/trino/plugin/apache-ranger/conf
-      ln -s /usr/lib/trino/etc/ranger-trino-security.xml usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-security.xml
-      ln -s /usr/lib/trino/etc/ranger-trino-audit.xml usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-audit.xml
+      ln -s /usr/lib/trino/etc/ranger-trino-security.xml \
+        usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-security.xml
+      ln -s /usr/lib/trino/etc/ranger-trino-audit.xml \
+        usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-audit.xml
       cp -r usr ${CRAFT_PART_INSTALL}/
     stage:
       - usr/lib/trino/plugin/apache-ranger/conf

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,8 +3,8 @@
 ---
 
 name: charmed-trino-rock
-base: ubuntu@22.04
-version: 436-22.04-edge
+base: ubuntu@24.04
+version: 468-24.04-edge
 summary: Charmed TrinoROCK OCI
 description: |
   Trino is an ANSI SQL compliant query engine,
@@ -21,8 +21,8 @@ platforms:
 run_user: _daemon_
 
 environment:
-  JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/trino/bin # yamllint disable-line
+  JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/trino/bin:/usr/lib/jvm/java-23-openjdk-amd64/bin/ # yamllint disable-line
 
 services:
   trino-server:
@@ -34,21 +34,31 @@ services:
 parts:
   trino:
     plugin: nil
-    source: https://github.com/canonical/trino.git
-    source-branch: "trino-436-oauth"
+    source: https://github.com/trinodb/trino.git
+    source-tag: "468"
     source-type: git
     build-packages:
-      - build-essential
       - curl
-      - git
       - maven
-      - gcc
-      - openjdk-21-jdk-headless
     build-environment:
-      - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
+      - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
     override-build: |
-      ./mvnw clean install -DskipTests -Dair.check.skip-all=true \
-        -pl '!:trino-server-rpm,!docs'
+      # TODO: the following block needs to be removed when openjdk-23-jdk-headless becomes available on 25.04
+
+      curl https://download.java.net/java/GA/jdk23.0.1/c28985cbf10d4e648e4004050f8781aa/11/GPL/openjdk-23.0.1_linux-x64_bin.tar.gz\
+        --output jdk-23.0.1.tar.gz 
+      mkdir -p ${JAVA_HOME}
+      mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}
+      tar -xzf jdk-23.0.1.tar.gz
+      cp -r jdk-23.0.1/* ${JAVA_HOME}
+      cp -r jdk-23.0.1/* ${CRAFT_PART_INSTALL}${JAVA_HOME}
+      update-alternatives --install /usr/bin/java java ${JAVA_HOME}/bin/java 1
+      update-alternatives --install /usr/bin/javac javac ${JAVA_HOME}/bin/javac 1      
+      update-alternatives --set java ${JAVA_HOME}/bin/java
+      update-alternatives --set javac ${JAVA_HOME}/bin/javac
+
+
+      ./mvnw clean install -DskipTests -Dair.check.skip-all=true -pl '!:trino-server-rpm,!docs'
 
       tar -xzf core/trino-server/target/trino-server-*.tar.gz \
         --directory=${CRAFT_PART_INSTALL} \
@@ -60,7 +70,9 @@ parts:
       mkdir -p \
         ${CRAFT_PART_INSTALL}/data/trino/var/run \
         ${CRAFT_PART_INSTALL}/data/trino/var/log \
+        ${CRAFT_PART_INSTALL}/data/trino/var/cache \
         ${CRAFT_PART_INSTALL}/usr/lib/trino/var
+
     organize:
       bin: usr/lib/trino/bin
       lib: usr/lib/trino/lib
@@ -72,7 +84,7 @@ parts:
       plugin/postgresql: usr/lib/trino/plugin/postgresql
       plugin/prometheus: usr/lib/trino/plugin/prometheus
       plugin/redis: usr/lib/trino/plugin/redis
-      plugin/ranger: usr/lib/trino/plugin/ranger
+      plugin/apache-ranger: usr/lib/trino/plugin/apache-ranger
       plugin/hive: usr/lib/trino/plugin/hive
       trino-cli: usr/lib/trino/bin/trino-cli
     stage:
@@ -81,12 +93,17 @@ parts:
       - usr/lib/trino/lib
       - usr/lib/trino/plugin
       - usr/lib/trino/var
+      - usr/lib/jvm
     permissions:
       - path: data/trino/var/run
         owner: 584792
         group: 584792
         mode: "755"
       - path: data/trino/var/log
+        owner: 584792
+        group: 584792
+        mode: "755"
+      - path: data/trino/var/cache
         owner: 584792
         group: 584792
         mode: "755"
@@ -111,41 +128,9 @@ parts:
         group: 584792
         mode: "755"
 
-  ranger-plugin:
-    after: [trino]
-    plugin: maven
-    maven-parameters: ["-DskipTests=true", "-Drat.skip=true", "-P ranger-trino-plugin,-linux -am", "-pl distro,plugin-trino,ranger-trino-plugin-shim,agents-installer,credentialbuilder"] # yamllint disable-line
-    source: https://github.com/canonical/ranger.git
-    source-branch: ranger-2.4-0-trino-436
-    source-type: git
-    build-packages:
-      - build-essential
-      - maven
-      - openjdk-21-jdk-headless
-    build-environment:
-      - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
-    override-build: |
-      craftctl default
-      mkdir -p ${CRAFT_PART_INSTALL}/usr/lib/ranger
-
-      # Unpack trino plugin file
-      tar xvfz target/ranger-3.0.0-SNAPSHOT-trino-plugin.tar.gz \
-        --directory=${CRAFT_PART_INSTALL}/usr/lib/ranger/ \
-        --strip-components=1
-    stage:
-      - usr/lib/ranger
-        # We will not stage the `ranger-trino-security.xml.
-        # We are staging this from local-files`
-      - "-usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml" # yamllint disable-line
-    permissions:
-      - path: usr/lib/ranger
-        owner: 584792
-        group: 584792
-        mode: "755"
-
   local-files:
     plugin: dump
-    after: [trino, ranger-plugin]
+    after: [trino]
     source: ./local-files
     organize:
       jvm.config: usr/lib/trino/etc/jvm.config
@@ -153,9 +138,13 @@ parts:
       config.properties: usr/lib/trino/etc/config.properties
       jmx-config.yaml: usr/lib/trino/etc/trino/jmx/config.yaml
       trino-entrypoint.sh: entrypoint.sh
-      ranger-trino-security.xml: usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml # yamllint disable-line
+      ranger-trino-security.xml: usr/lib/trino/etc/ranger-trino-security.xml # yamllint disable-line
+      ranger-trino-audit.xml: usr/lib/trino/etc/ranger-trino-audit.xml # yamllint disable-line
+      ranger-policymgr-ssl.xml: usr/lib/trino/etc/ranger-policymgr-ssl.xml # yamllint disable-line
     stage:
-      - usr/lib/ranger/install/conf.templates/enable/ranger-trino-security.xml
+      - usr/lib/trino/etc/ranger-trino-security.xml
+      - usr/lib/trino/etc/ranger-trino-audit.xml
+      - usr/lib/trino/etc/ranger-policymgr-ssl.xml
       - usr/lib/trino/etc/jvm.config
       - usr/lib/trino/etc/node.properties
       - usr/lib/trino/etc/config.properties
@@ -171,6 +160,22 @@ parts:
         group: 584792
         mode: "755"
 
+  # This is a workaround of an issue with ranger groups in trino 468 
+  # the author is aware of the problem and is supposed to fix it in the
+  # next release. At that point this part can be deleted.
+  trino-patch:
+    plugin: nil
+    after: [local-files]
+    override-build: |
+      mkdir -p /usr/lib/trino/etc/
+      touch /usr/lib/trino/etc/ranger-trino-security.xml /usr/lib/trino/etc/ranger-trino-audit.xml
+      mkdir -p usr/lib/trino/plugin/apache-ranger/conf
+      ln -s /usr/lib/trino/etc/ranger-trino-security.xml usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-security.xml
+      ln -s /usr/lib/trino/etc/ranger-trino-audit.xml usr/lib/trino/plugin/apache-ranger/conf/ranger-trino-audit.xml
+      cp -r usr ${CRAFT_PART_INSTALL}/
+    stage:
+      - usr/lib/trino/plugin/apache-ranger/conf
+
   jmx-exporter:
     plugin: maven
     after: [trino]
@@ -179,7 +184,7 @@ parts:
     source-type: git
     source-tag: parent-0.19.0
     build-environment:
-      - JAVA_HOME: /usr/lib/jvm/java-21-openjdk-amd64
+      - JAVA_HOME: /usr/lib/jvm/java-23-openjdk-amd64
     organize:
       jar/jmx_prometheus_javaagent-0.19.0.jar: usr/lib/trino/lib/jmx_prometheus_javaagent.jar # yamllint disable-line
     stage:
@@ -201,9 +206,9 @@ parts:
 
   package-management:
     plugin: nil
-    after: [trino, local-files, ranger-plugin]
+    after: [trino, local-files]
     overlay-packages:
-      - openjdk-21-jdk-headless
+      # - openjdk-23-jdk-headless
       - ca-certificates
       - python-is-python3
     stage-packages:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -46,7 +46,7 @@ parts:
     override-build: |
       # TODO: the following block can be removed when the ubuntu base
       # used for the rock supports the "openjdk-xx-jdk-headless"
-      # corrseponding to the java version used in Trino
+      # corresponding to the java version used in Trino
       curl ${JAVA_URL} --output jdk-23.0.1.tar.gz
       mkdir -p ${JAVA_HOME}
       mkdir -p ${CRAFT_PART_INSTALL}${JAVA_HOME}


### PR DESCRIPTION
Upgrading Trino to the latest version (has support for iceberg / hive metastore)

- ranger plugin is integrated, but new configuration files are needed: https://trino.io/docs/current/security/ranger-access-control.html
- it requires java23, which is not officially supported on 24.04. 24.10 has it but rocks accept only lts-es. So i am downloading it from the website. This part can be removed when the current lts supports the java version used in Trino.
- the trino patch part is a workaround for an issue with the order trino loads configs. The symbolic link links our standard config files with some files that mistakenly have higher priority (so they would normally overwrite our config, but with a symlink they are the same).... the guru told me, it is expected to be in the next ranger release...2.6.x